### PR TITLE
Add the options to run matmul on IPU models

### DIFF
--- a/ipu/matmul_bench.cpp
+++ b/ipu/matmul_bench.cpp
@@ -12,6 +12,7 @@
 #include <poplar/Engine.hpp>
 #include <poplar/Graph.hpp>
 #include <poplar/IPUModel.hpp>
+#include <poplar/exceptions.hpp>
 #include <poplin/MatMul.hpp>
 #include <poplin/codelets.hpp>
 #include <popops/Cast.hpp>
@@ -43,23 +44,28 @@ poplar::Device attach(size_t count) {
     throw std::runtime_error("Couldn't attach to device");
 }
 
-poplar::Device makeDevice(std::string deviceType) {
-    if (deviceType.rfind("IpuModel", 0) == 0) {
-        auto type2model = [&deviceType] {
-            std::string ret = "ipu2";
-            if (deviceType == "IpuModel21") {
-                ret = "ipu21";
-            } else if (deviceType == "IpuModel30") {
-                ret = "ipu30";
-            }
-            return ret;
-        };
+poplar::Device makeDevice(std::string deviceType, std::string modelFile) {
+    try {
+        if (deviceType.rfind("IpuModel", 0) == 0) {
+            auto type2model = [&] {
+                std::string ret = "ipu2";
+		auto sLen = sizeof("IpuModel") - 1;
+                if (deviceType == "IpuModelConfig") {
+	            ret = "ipu:" + modelFile;
+                } else if (deviceType.size() > sLen) {
+                    ret = "ipu" + deviceType.substr(sLen);
+		}
+                return ret;
+            };
 
-        auto ipuModel = poplar::IPUModel{type2model().c_str()};
-        return ipuModel.createDevice();
+            auto ipuModel = poplar::IPUModel{type2model().c_str()};
+            return ipuModel.createDevice();
+        }
+        return attach(1);
+    } catch(const poplar::poplar_error &e) {
+        std::cerr << "Could not create device with type: '" + deviceType + "' and model file: '" + modelFile + "'\n";
+        throw e;
     }
-
-    return attach(1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -552,15 +558,11 @@ int main(int argc, char** argv) {
 
     // Argument parsing
     cxxopts::Options options("matmul_bench", "A simple wrapper for matmul ops");
-
-    // DeviceType deviceType = DeviceType::IpuModel2;
-
-    // clang-format off
     options.add_options()
         ("help", "Produce help message")
         ("compile-only", "Stop after compilation; don't run the program",
 	 cxxopts::value<bool>()->default_value("false"))
-	("device-type",  "Hw | IpuModel2 | IpuModel21 | IpuModel30",
+	("device-type",  "Hw | IpuModel2 | IpuModel21 | IpuModelConfig",
          cxxopts::value<std::string>()->default_value("Hw"))
         ("profile", "Enable profiling and print profiling report",
 	 cxxopts::value<bool>()->default_value("false"))
@@ -595,6 +597,8 @@ int main(int argc, char** argv) {
          "Options to use for the matrix multiplication, specified as a JSON "
          "string, e.g. {\"key\":\"value\"}",
 	 cxxopts::value<std::string>())
+	("model-file", "Path to JSON file for model configuration",
+	 cxxopts::value<std::string>()->default_value(""))
     ;
     // clang-format on
 
@@ -611,10 +615,7 @@ int main(int argc, char** argv) {
     }
 
     // bool compileOnly = result["compile-only"].as<bool>();
-    std::string deviceType{};
-    if (result.count("device-type")) {
-        deviceType = result["device-type"].as<std::string>();
-    }
+    std::string deviceType = result["device-type"].as<std::string>();
     bool ignoreData = result["ignore-data"].as<bool>();
     bool profile = result["profile"].as<bool>();
     std::string profileDir = result["profile-dir"].as<std::string>();;
@@ -627,6 +628,11 @@ int main(int argc, char** argv) {
         matmulOptions = result["matmul-options"].as<std::string>();
     }
 */
+    std::string modelFile = result["model-file"].as<std::string>();
+    if (modelFile.size() > 0) {
+        deviceType = "IpuModelConfig";
+    }
+
     params.groups = result["groups"].as<unsigned>();
     if (result.count("n")) {
         params.batchSize = result["n"].as<unsigned>();
@@ -689,7 +695,7 @@ int main(int argc, char** argv) {
     } else if (implementation == ImplementationType::DynamicBlockSparse) {
         impl.reset(new DynamicBlockSparseImpl(problem));
     }
-    const auto device = makeDevice(deviceType);
+    const auto device = makeDevice(deviceType, modelFile);
     poplar::Graph graph(device.getTarget());
     popops::addCodelets(graph);
     poplin::addCodelets(graph);

--- a/ipu/matmul_bench.py
+++ b/ipu/matmul_bench.py
@@ -70,7 +70,7 @@ def make_arg_parser(parser=None):
         "--device-type",
         type=str,
         default="Hw",
-        choices=["Hw", "IpuModel", "IpuModel2", "IpuModel21"],
+        choices=["Hw", "IpuModel", "IpuModel2", "IpuModel21", "IpuModelConfig"],
         help="Which device type should be used."
     )
 
@@ -104,6 +104,12 @@ def make_arg_parser(parser=None):
         type=str,
         default="./profile",
         help="The folder where to store the profile file"
+    )
+
+    parser.add_argument(
+        "--model-file",
+        type=str,
+        help="The path to the JSON model config file"
     )
 
     return parser
@@ -194,6 +200,8 @@ if __name__ == '__main__':
         cmd += " --partials-type half"
     cmd += f" --profile-dir {args.profile_dir}"
     cmd += f" --device-type {args.device_type}"
+    if args.model_file is not None:
+        cmd += f" --model-file {args.model_file}"
 
     print(cmd)
     args_list = shlex.split(cmd)
@@ -203,6 +211,8 @@ if __name__ == '__main__':
 
     # Output a single flag to indicate whether the run was successful.
     print(f"Success: {proc.returncode == 0}")
+    if proc.returncode != 0:
+        exit(1)
 
     # Profile reports are generated and can contain useful information,
     # even for unsuccessful runs (e.g. OOM errors or validation failures),

--- a/ipu/matmul_bench.py
+++ b/ipu/matmul_bench.py
@@ -70,7 +70,7 @@ def make_arg_parser(parser=None):
         "--device-type",
         type=str,
         default="Hw",
-        choices=["Cpu", "Sim1", "Sim2", "Hw", "IpuModel1", "IpuModel2"],
+        choices=["Hw", "IpuModel", "IpuModel2", "IpuModel21"],
         help="Which device type should be used."
     )
 
@@ -193,6 +193,7 @@ if __name__ == '__main__':
     if args.partials == "half" and args.type == "half":
         cmd += " --partials-type half"
     cmd += f" --profile-dir {args.profile_dir}"
+    cmd += f" --device-type {args.device_type}"
 
     print(cmd)
     args_list = shlex.split(cmd)


### PR DESCRIPTION
Both the `matmul_bench` and the wrapper script have been upgraded with CLI options to support IPU models:

- `--device-type` can take one of `Hw` (default), `IpuModel`, `IpuModel2`, `IpuModel21`, `IpuModelConfig`
- `--model-file` is a path to a JSON model config file (empty string by default). It works in combination with `IpuModelConfig`. If supplied, it takes precedence over the device type.

Use cases:
`python matmul_bench.py -m 256 -n 16 -k 512 --device-type IpuModel21`
`python matmul_bench.py -m 256 -n 16 -k 512 --device-type IpuModelConfig --model-file ~/model.json`
equivalent to
`python matmul_bench.py -m 256 -n 16 -k 512 --model-file ~/model.json`